### PR TITLE
Fix copy operation on non-m4 builds

### DIFF
--- a/netcdf-src/Cargo.toml
+++ b/netcdf-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcdf-src"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Magnus Ulimoen <magnusu@met.no>"]
 edition = "2018"
 description = "Build scripts for building `netCDF` from source"


### PR DESCRIPTION
This to fix the windows static builds