### PR TITLE
Allow filenames with invalid utf8 (unix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,5 +124,8 @@ jobs:
       - name: Install Rust (${{matrix.rust}})
         uses: actions-rs/toolchain@v1
         with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}
+      - name: Change to older toolchain
+        if: matrix.os == 'macos'
+        run: sudo xcode-select -s "/Applications/Xcode_11.7.app"
       - name: Build and test
         run: cargo test -vv --features static

--- a/examples/ncdump.rs
+++ b/examples/ncdump.rs
@@ -22,7 +22,7 @@ fn main() {
 fn run(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let file = netcdf::open(path)?;
 
-    println!("{}", file.path()?);
+    println!("{}", file.path()?.to_str().unwrap());
     print_file(&file)
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,7 +42,7 @@ fn root_dims() {
     let f = test_location().join("simple_xy.nc");
 
     let file = netcdf::open(&f).unwrap();
-    assert_eq!(f.to_str().unwrap(), file.path().unwrap());
+    assert_eq!(f, file.path().unwrap());
 
     assert_eq!(file.dimension("x").unwrap().len(), 6);
     assert_eq!(file.dimension("y").unwrap().len(), 12);
@@ -315,7 +315,7 @@ fn create() {
     let f = d.path().join("create.nc");
 
     let file = netcdf::create(&f).unwrap();
-    assert_eq!(f.to_str().unwrap(), file.path().unwrap());
+    assert_eq!(f, file.path().unwrap());
 }
 
 #[test]
@@ -1547,4 +1547,21 @@ fn open_to_find_unlim_dim() {
     let dim = &var.dimensions()[0];
     assert_eq!(dim.len(), 6);
     assert!(dim.is_unlimited());
+}
+
+#[test]
+#[cfg(unix)]
+fn invalid_utf8_as_path() {
+    let d = tempfile::tempdir().unwrap();
+
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    let bytes = b"\xff\xff.nc";
+    let path = OsStr::from_bytes(&bytes[..]);
+    let path = std::path::PathBuf::from(path);
+    let fullpath = d.path().join(&path);
+    let file = netcdf::create(&fullpath).unwrap();
+
+    let retrieved_path = file.path().unwrap();
+    assert_eq!(fullpath, retrieved_path);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1550,7 +1550,7 @@ fn open_to_find_unlim_dim() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 fn invalid_utf8_as_path() {
     let d = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
This implementation allows opening and creating files with filenames which are not well-formed UTF8, as can be seen in the added test.

The newest `xcode` for macos gives a (correct) compilation error for `hdf5`, so a workaround has been included here.

Partial fix of #67