### PR TITLE
Update netcdf-c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,6 @@ jobs:
       - name: Install Rust (${{matrix.rust}})
         uses: actions-rs/toolchain@v1
         with: {toolchain: '${{matrix.rust}}', profile: minimal, override: true}
-      - name: Change to older toolchain
-        if: matrix.os == 'macos-11'
-        run: sudo xcode-select -s "/Applications/Xcode_11.7.app"
       - name: Build and test
         run: cargo test -vv --features static --workspace
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "netcdf-sys/source"]
+[submodule "netcdf-src/source"]
 	path = netcdf-src/source
 	url = https://github.com/magnusuMET/netcdf-c.git
-        branch = bugfix/v4.7.4-build_patched
+        branch = bugfix/patched_v4.9.1_for_rust_netcdf

--- a/netcdf-src/Cargo.toml
+++ b/netcdf-src/Cargo.toml
@@ -32,6 +32,7 @@ dap = []
 
 [dependencies]
 hdf5-sys = { version = "0.8.0", features = ["hl", "deprecated", "zlib"] }
+libz-sys = { version = "1.0.25" }
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -4,12 +4,33 @@ macro_rules! feature {
     };
 }
 
+fn get_hdf5_version() -> String {
+    let (major, minor, patch) = std::env::vars()
+        .filter_map(|(key, value)| {
+            key.strip_prefix("DEP_HDF5_VERSION_").map(|key| {
+                assert_eq!(value, "1");
+                let mut version = key.split('_');
+                let major: usize = version.next().unwrap().parse().unwrap();
+                let minor: usize = version.next().unwrap().parse().unwrap();
+                let patch: usize = version.next().unwrap().parse().unwrap();
+
+                (major, minor, patch)
+            })
+        })
+        .max()
+        .expect("Crate hdf5 should have emitted a hdf5 version");
+
+    format!("{major}.{minor}.{patch}")
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let hdf5_incdir = std::env::var("DEP_HDF5_INCLUDE").unwrap();
     let hdf5_lib = std::env::var("DEP_HDF5_LIBRARY").unwrap();
     let hdf5_hl_lib = std::env::var("DEP_HDF5_HL_LIBRARY").unwrap();
+
+    let hdf5_version = get_hdf5_version();
 
     let mut netcdf_config = cmake::Config::new("source");
     netcdf_config
@@ -23,18 +44,28 @@ fn main() {
         .define("ENABLE_PARALLEL_TESTS", "OFF")
         .define("ENABLE_FILTER_TESTING", "OFF")
         .define("ENABLE_BASH_SCRIPT_TESTING", "OFF")
+        .define("ENABLE_PLUGINS", "OFF")
+        .define("PLUGIN_INSTALL_DIR", "OFF")
         //
+        .define("HDF5_VERSION", &hdf5_version)
         .define("HDF5_C_LIBRARY", &hdf5_lib)
         .define("HDF5_HL_LIBRARY", &hdf5_hl_lib)
         .define("HDF5_INCLUDE_DIR", hdf5_incdir)
         //
+        .define("ENABLE_NCZARR", "OFF") // TODO: requires a bunch of deps
+        //
         .define("ENABLE_DAP", "OFF") // TODO: feature flag, requires curl
+        .define("ENABLE_BYTERANGE", "OFF") // TODO: feature flag, requires curl
         .define("ENABLE_DAP_REMOTE_TESTS", "OFF")
         //
         .profile("RelWithDebInfo"); // TODO: detect opt-level
 
+    let zlib_include_dir = std::env::var("DEP_Z_INCLUDE").unwrap();
+    netcdf_config.define("ZLIB_ROOT", format!("{zlib_include_dir}/.."));
+
     if feature!("DAP").is_ok() {
         netcdf_config.define("ENABLE_DAP", "ON");
+        netcdf_config.define("ENABLE_BYTERANGE", "ON");
     }
 
     let netcdf = netcdf_config.build();

--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -282,6 +282,8 @@ fn main() {
         Version::new(4, 7, 4),
         Version::new(4, 8, 0),
         Version::new(4, 8, 1),
+        Version::new(4, 9, 0),
+        Version::new(4, 9, 1),
     ];
 
     if !versions.contains(&metaheader.version) {


### PR DESCRIPTION
Updates `netcdf-c` to 4.9.1. Due to an upstream bug in the cmake config we need a lightly patched version for the release to support non-m4 installs.

~~Waiting for a resolution on https://github.com/Unidata/netcdf-c/issues/2367. This was previously patched with a fork of `netcdf-c`~~

Fixes #91 