### PR TITLE
Add the shuffle option to the compression method

### DIFF
--- a/netcdf/src/variable.rs
+++ b/netcdf/src/variable.rs
@@ -170,16 +170,19 @@ impl<'g> VariableMut<'g> {
     /// compression (good for CPU bound tasks), and 9 providing the
     /// highest compression level (good for memory bound tasks)
     ///
+    /// `shuffle` enables a filter to reorder bytes before compressing, which
+    /// can improve compression ratios
+    ///
     /// # Errors
     ///
     /// Not a `netcdf-4` file or `deflate_level` not valid
-    pub fn compression(&mut self, deflate_level: nc_type) -> error::Result<()> {
+    pub fn compression(&mut self, deflate_level: nc_type, shuffle: bool) -> error::Result<()> {
         unsafe {
             error::checked(super::with_lock(|| {
                 nc_def_var_deflate(
                     self.ncid,
                     self.varid,
-                    <_>::from(false),
+                    shuffle.into(),
                     <_>::from(true),
                     deflate_level,
                 )

--- a/netcdf/tests/group.rs
+++ b/netcdf/tests/group.rs
@@ -64,7 +64,7 @@ fn find_variable() {
 
     for mut var in group.variables_mut() {
         if var.dimensions().len() > 0 {
-            var.compression(3).unwrap();
+            var.compression(3, false).unwrap();
         }
         if var.name() == "z" {
             var.chunking(&[1]).unwrap();

--- a/netcdf/tests/lib.rs
+++ b/netcdf/tests/lib.rs
@@ -903,7 +903,8 @@ fn set_compression_all_variables_in_a_group() {
         .expect("Could not create variable");
 
     for mut var in file.variables_mut() {
-        var.compression(9, false).expect("Could not set compression level");
+        var.compression(9, false)
+            .expect("Could not set compression level");
     }
 }
 

--- a/netcdf/tests/lib.rs
+++ b/netcdf/tests/lib.rs
@@ -854,7 +854,7 @@ fn use_compression_chunking() {
     file.add_dimension("x", 10).unwrap();
 
     let var = &mut file.add_variable::<i32>("compressed", &["x"]).unwrap();
-    var.compression(5).unwrap();
+    var.compression(5, false).unwrap();
     var.chunking(&[5]).unwrap();
 
     let v = vec![0i32; 10];
@@ -863,7 +863,7 @@ fn use_compression_chunking() {
     let var = &mut file
         .add_variable::<i32>("compressed2", &["x", "x"])
         .unwrap();
-    var.compression(9).unwrap();
+    var.compression(9, true).unwrap();
     var.chunking(&[5, 5]).unwrap();
     var.put_values(&[1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10], (..10, ..1))
         .unwrap();
@@ -903,7 +903,7 @@ fn set_compression_all_variables_in_a_group() {
         .expect("Could not create variable");
 
     for mut var in file.variables_mut() {
-        var.compression(9).expect("Could not set compression level");
+        var.compression(9, false).expect("Could not set compression level");
     }
 }
 


### PR DESCRIPTION
The `shuffle` parameter to `nc_def_var_deflate()` is now exposed as a new argument to the `compression()` method of `VariableMut`.

The tests were updated to add in the new argument as sometimes `true` or `false` in order to ensure both cases get tested.

Closes #100 