### PR TITLE
Fixed a broken link in lib.rs

### DIFF
--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -13,7 +13,7 @@
 //! `open()`, `create()`, and `append()`.
 //!
 //! For more information see:
-//! * [The official introduction to `netCDF`](https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_introduction.html)
+//! * [The official introduction to `netCDF`](https://docs.unidata.ucar.edu/netcdf-c/current/index.html)
 //! * [The `netCDF-c` repository](https://github.com/Unidata/netcdf-c)
 //!
 //! # Examples

--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -13,7 +13,7 @@
 //! `open()`, `create()`, and `append()`.
 //!
 //! For more information see:
-//! * [The official introduction to `netCDF`](https://docs.unidata.ucar.edu/netcdf-c/current/index.html)
+//! * [The official introduction to `netCDF`](https://docs.unidata.ucar.edu/nug/current/netcdf_introduction.html)
 //! * [The `netCDF-c` repository](https://github.com/Unidata/netcdf-c)
 //!
 //! # Examples


### PR DESCRIPTION
The original link for "The official introduction to `netCDF`" led to a 404. I believe this is the right one.