### PR TITLE
Bump netcdf source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "netcdf-src/source"]
 	path = netcdf-src/source
-	url = https://github.com/magnusuMET/netcdf-c.git
-        branch = bugfix/patched_v4.9.1_for_rust_netcdf
+	url = https://github.com/Unidata/netcdf-c
+	rev = 718349098979dcc4a2b13c8d957ef31361dd636b

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "netcdf-src/source"]
 	path = netcdf-src/source
-	url = https://github.com/Unidata/netcdf-c
+	url = https://github.com/gigainfosystems/netcdf-c
 	rev = 718349098979dcc4a2b13c8d957ef31361dd636b

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "netcdf-src/source"]
 	path = netcdf-src/source
 	url = https://github.com/gigainfosystems/netcdf-c
-	rev = 718349098979dcc4a2b13c8d957ef31361dd636b
+	rev = ecd665aa0f1f5d68f27ce654c684728305cb03d9


### PR DESCRIPTION
This pulls in https://github.com/Unidata/netcdf-c/pull/2756 which fixes an issue with building `netcdf-src` in a directory containing a whitespace somewhere in the path.