### PR TITLE
Update zstd and bzip2 function signatures

### DIFF
--- a/netcdf-sys/src/filter.rs
+++ b/netcdf-sys/src/filter.rs
@@ -18,6 +18,10 @@ extern "C" {
 
     pub fn nc_inq_filter_avail(ncid: c_int, id: c_uint) -> c_int;
 
+}
+
+#[cfg(feature = "4.9.0")]
+extern "C" {
     pub fn nc_def_var_bzip2(ncid: c_int, varid: c_int, level: c_int) -> c_int;
     pub fn nc_inq_var_bzip2(
         ncid: c_int,

--- a/netcdf-sys/src/filter.rs
+++ b/netcdf-sys/src/filter.rs
@@ -26,12 +26,12 @@ extern "C" {
         levelp: *mut c_int,
     ) -> c_int;
 
-    pub fn nc_def_var_zstandars(ncid: c_int, varid: c_int, level: c_int) -> c_int;
+    pub fn nc_def_var_zstandard(ncid: c_int, varid: c_int, level: c_int) -> c_int;
     pub fn nc_inq_var_zstandard(
         ncid: c_int,
         varid: c_int,
         hasfilterp: *mut c_int,
-        levelp: *mut c_uint,
+        levelp: *mut c_int,
     ) -> c_int;
 
     pub fn nc_def_var_blosc(


### PR DESCRIPTION
Some functions relating to ztd and bzip2 compression on variables [were added in netCDF 4.9.0](https://github.com/Unidata/netcdf-c/blob/v4.9.0/include/netcdf_filter.h) so I updated their function signatures to not show up for earlier versions (the `netcdf-sys/src/filter.rs` module is already enabled with `#[cfg(feature = "4.8.0")]`).

Additionally, a couple of zstd functions had wrong signatures, so they are updated here.