### PR TITLE
Flatten import structure

### DIFF
--- a/netcdf/examples/ncdump.rs
+++ b/netcdf/examples/ncdump.rs
@@ -91,7 +91,7 @@ fn print_file(g: &netcdf::File) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn print_group(g: &netcdf::group::Group) -> Result<(), Box<dyn std::error::Error>> {
+fn print_group(g: &netcdf::Group) -> Result<(), Box<dyn std::error::Error>> {
     println!("Group: {}", g.name());
 
     let mut dims = g.dimensions().peekable();

--- a/netcdf/src/attribute.rs
+++ b/netcdf/src/attribute.rs
@@ -82,7 +82,7 @@ impl<'a> Attribute<'a> {
     ///
     /// Unsupported type or netcdf error
     #[allow(clippy::too_many_lines)]
-    pub fn value(&self) -> error::Result<AttrValue> {
+    pub fn value(&self) -> error::Result<AttributeValue> {
         let attlen = self.num_elems()?;
         let typ = self.typ()?;
 
@@ -100,7 +100,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Uchar(value))
+                    Ok(AttributeValue::Uchar(value))
                 }
                 len => {
                     let mut values = vec![0_u8; len];
@@ -114,7 +114,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Uchars(values))
+                    Ok(AttributeValue::Uchars(values))
                 }
             },
             NC_BYTE => match attlen {
@@ -130,7 +130,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Schar(value))
+                    Ok(AttributeValue::Schar(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -144,7 +144,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Schars(values))
+                    Ok(AttributeValue::Schars(values))
                 }
             },
             NC_SHORT => match attlen {
@@ -160,7 +160,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Short(value))
+                    Ok(AttributeValue::Short(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -174,7 +174,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Shorts(values))
+                    Ok(AttributeValue::Shorts(values))
                 }
             },
             NC_USHORT => match attlen {
@@ -190,7 +190,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Ushort(value))
+                    Ok(AttributeValue::Ushort(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -204,7 +204,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Ushorts(values))
+                    Ok(AttributeValue::Ushorts(values))
                 }
             },
             NC_INT => match attlen {
@@ -220,7 +220,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Int(value))
+                    Ok(AttributeValue::Int(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -234,7 +234,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Ints(values))
+                    Ok(AttributeValue::Ints(values))
                 }
             },
             NC_UINT => match attlen {
@@ -250,7 +250,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Uint(value))
+                    Ok(AttributeValue::Uint(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -264,7 +264,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Uints(values))
+                    Ok(AttributeValue::Uints(values))
                 }
             },
             NC_INT64 => match attlen {
@@ -280,7 +280,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Longlong(value))
+                    Ok(AttributeValue::Longlong(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -295,7 +295,7 @@ impl<'a> Attribute<'a> {
                         }))?;
                     }
 
-                    Ok(AttrValue::Longlongs(values))
+                    Ok(AttributeValue::Longlongs(values))
                 }
             },
             NC_UINT64 => match attlen {
@@ -311,7 +311,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Ulonglong(value))
+                    Ok(AttributeValue::Ulonglong(value))
                 }
                 len => {
                     let mut values = vec![0; len as _];
@@ -326,7 +326,7 @@ impl<'a> Attribute<'a> {
                         }))?;
                     }
 
-                    Ok(AttrValue::Ulonglongs(values))
+                    Ok(AttributeValue::Ulonglongs(values))
                 }
             },
             NC_FLOAT => match attlen {
@@ -342,7 +342,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Float(value))
+                    Ok(AttributeValue::Float(value))
                 }
                 len => {
                     let mut values = vec![0.0; len as _];
@@ -356,7 +356,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Floats(values))
+                    Ok(AttributeValue::Floats(values))
                 }
             },
             NC_DOUBLE => match attlen {
@@ -372,7 +372,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Double(value))
+                    Ok(AttributeValue::Double(value))
                 }
                 len => {
                     let mut values = vec![0.0; len as _];
@@ -386,7 +386,7 @@ impl<'a> Attribute<'a> {
                             )
                         }))?;
                     }
-                    Ok(AttrValue::Doubles(values))
+                    Ok(AttributeValue::Doubles(values))
                 }
             },
             NC_CHAR => {
@@ -403,7 +403,7 @@ impl<'a> Attribute<'a> {
                     }))?;
                 }
                 let pos = buf.iter().position(|&x| x == 0).unwrap_or(buf.len());
-                Ok(AttrValue::Str(String::from(String::from_utf8_lossy(
+                Ok(AttributeValue::Str(String::from(String::from_utf8_lossy(
                     &buf[..pos],
                 ))))
             }
@@ -432,7 +432,7 @@ impl<'a> Attribute<'a> {
                         .collect();
                     super::with_lock(|| nc_free_string(attlen, buf.as_mut_ptr()));
                 }
-                Ok(AttrValue::Strs(result))
+                Ok(AttributeValue::Strs(result))
             }
             x => Err(error::Error::TypeUnknown(x)),
         }
@@ -503,7 +503,7 @@ impl<'a> Iterator for AttributeIterator<'a> {
 /// returned from the file
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq)]
-pub enum AttrValue {
+pub enum AttributeValue {
     Uchar(u8),
     Uchars(Vec<u8>),
     Schar(i8),
@@ -535,16 +535,16 @@ impl<'a> Attribute<'a> {
         ncid: nc_type,
         varid: nc_type,
         name: &str,
-        val: AttrValue,
+        val: AttributeValue,
     ) -> error::Result<Self> {
         let cname = super::utils::short_name_to_bytes(name)?;
 
         error::checked(unsafe {
             match val {
-                AttrValue::Uchar(x) => super::with_lock(|| {
+                AttributeValue::Uchar(x) => super::with_lock(|| {
                     nc_put_att_uchar(ncid, varid, cname.as_ptr().cast(), NC_UBYTE, 1, &x)
                 }),
-                AttrValue::Uchars(x) => super::with_lock(|| {
+                AttributeValue::Uchars(x) => super::with_lock(|| {
                     nc_put_att_uchar(
                         ncid,
                         varid,
@@ -554,10 +554,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Schar(x) => super::with_lock(|| {
+                AttributeValue::Schar(x) => super::with_lock(|| {
                     nc_put_att_schar(ncid, varid, cname.as_ptr().cast(), NC_BYTE, 1, &x)
                 }),
-                AttrValue::Schars(x) => super::with_lock(|| {
+                AttributeValue::Schars(x) => super::with_lock(|| {
                     nc_put_att_schar(
                         ncid,
                         varid,
@@ -567,10 +567,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Ushort(x) => super::with_lock(|| {
+                AttributeValue::Ushort(x) => super::with_lock(|| {
                     nc_put_att_ushort(ncid, varid, cname.as_ptr().cast(), NC_USHORT, 1, &x)
                 }),
-                AttrValue::Ushorts(x) => super::with_lock(|| {
+                AttributeValue::Ushorts(x) => super::with_lock(|| {
                     nc_put_att_ushort(
                         ncid,
                         varid,
@@ -580,10 +580,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Short(x) => super::with_lock(|| {
+                AttributeValue::Short(x) => super::with_lock(|| {
                     nc_put_att_short(ncid, varid, cname.as_ptr().cast(), NC_SHORT, 1, &x)
                 }),
-                AttrValue::Shorts(x) => super::with_lock(|| {
+                AttributeValue::Shorts(x) => super::with_lock(|| {
                     nc_put_att_short(
                         ncid,
                         varid,
@@ -593,10 +593,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Uint(x) => super::with_lock(|| {
+                AttributeValue::Uint(x) => super::with_lock(|| {
                     nc_put_att_uint(ncid, varid, cname.as_ptr().cast(), NC_UINT, 1, &x)
                 }),
-                AttrValue::Uints(x) => super::with_lock(|| {
+                AttributeValue::Uints(x) => super::with_lock(|| {
                     nc_put_att_uint(
                         ncid,
                         varid,
@@ -606,10 +606,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Int(x) => super::with_lock(|| {
+                AttributeValue::Int(x) => super::with_lock(|| {
                     nc_put_att_int(ncid, varid, cname.as_ptr().cast(), NC_INT, 1, &x)
                 }),
-                AttrValue::Ints(x) => super::with_lock(|| {
+                AttributeValue::Ints(x) => super::with_lock(|| {
                     nc_put_att_int(
                         ncid,
                         varid,
@@ -619,10 +619,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Ulonglong(x) => super::with_lock(|| {
+                AttributeValue::Ulonglong(x) => super::with_lock(|| {
                     nc_put_att_ulonglong(ncid, varid, cname.as_ptr().cast(), NC_UINT64, 1, &x)
                 }),
-                AttrValue::Ulonglongs(x) => super::with_lock(|| {
+                AttributeValue::Ulonglongs(x) => super::with_lock(|| {
                     nc_put_att_ulonglong(
                         ncid,
                         varid,
@@ -632,10 +632,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Longlong(x) => super::with_lock(|| {
+                AttributeValue::Longlong(x) => super::with_lock(|| {
                     nc_put_att_longlong(ncid, varid, cname.as_ptr().cast(), NC_INT64, 1, &x)
                 }),
-                AttrValue::Longlongs(x) => super::with_lock(|| {
+                AttributeValue::Longlongs(x) => super::with_lock(|| {
                     nc_put_att_longlong(
                         ncid,
                         varid,
@@ -645,10 +645,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Float(x) => super::with_lock(|| {
+                AttributeValue::Float(x) => super::with_lock(|| {
                     nc_put_att_float(ncid, varid, cname.as_ptr().cast(), NC_FLOAT, 1, &x)
                 }),
-                AttrValue::Floats(x) => super::with_lock(|| {
+                AttributeValue::Floats(x) => super::with_lock(|| {
                     nc_put_att_float(
                         ncid,
                         varid,
@@ -658,10 +658,10 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Double(x) => super::with_lock(|| {
+                AttributeValue::Double(x) => super::with_lock(|| {
                     nc_put_att_double(ncid, varid, cname.as_ptr().cast(), NC_DOUBLE, 1, &x)
                 }),
-                AttrValue::Doubles(x) => super::with_lock(|| {
+                AttributeValue::Doubles(x) => super::with_lock(|| {
                     nc_put_att_double(
                         ncid,
                         varid,
@@ -671,7 +671,7 @@ impl<'a> Attribute<'a> {
                         x.as_ptr(),
                     )
                 }),
-                AttrValue::Str(ref x) => super::with_lock(|| {
+                AttributeValue::Str(ref x) => super::with_lock(|| {
                     nc_put_att_text(
                         ncid,
                         varid,
@@ -680,7 +680,7 @@ impl<'a> Attribute<'a> {
                         x.as_ptr().cast(),
                     )
                 }),
-                AttrValue::Strs(ref x) => {
+                AttributeValue::Strs(ref x) => {
                     let cstrings: Vec<CString> = x
                         .iter()
                         .map(String::as_str)
@@ -750,132 +750,132 @@ impl<'a> Attribute<'a> {
 }
 
 // Boring implementations
-impl From<u8> for AttrValue {
+impl From<u8> for AttributeValue {
     fn from(x: u8) -> Self {
         Self::Uchar(x)
     }
 }
-impl From<Vec<u8>> for AttrValue {
+impl From<Vec<u8>> for AttributeValue {
     fn from(x: Vec<u8>) -> Self {
         Self::Uchars(x)
     }
 }
-impl From<i8> for AttrValue {
+impl From<i8> for AttributeValue {
     fn from(x: i8) -> Self {
         Self::Schar(x)
     }
 }
-impl From<Vec<i8>> for AttrValue {
+impl From<Vec<i8>> for AttributeValue {
     fn from(x: Vec<i8>) -> Self {
         Self::Schars(x)
     }
 }
-impl From<u16> for AttrValue {
+impl From<u16> for AttributeValue {
     fn from(x: u16) -> Self {
         Self::Ushort(x)
     }
 }
-impl From<Vec<u16>> for AttrValue {
+impl From<Vec<u16>> for AttributeValue {
     fn from(x: Vec<u16>) -> Self {
         Self::Ushorts(x)
     }
 }
-impl From<i16> for AttrValue {
+impl From<i16> for AttributeValue {
     fn from(x: i16) -> Self {
         Self::Short(x)
     }
 }
-impl From<Vec<i16>> for AttrValue {
+impl From<Vec<i16>> for AttributeValue {
     fn from(x: Vec<i16>) -> Self {
         Self::Shorts(x)
     }
 }
-impl From<u32> for AttrValue {
+impl From<u32> for AttributeValue {
     fn from(x: u32) -> Self {
         Self::Uint(x)
     }
 }
-impl From<Vec<u32>> for AttrValue {
+impl From<Vec<u32>> for AttributeValue {
     fn from(x: Vec<u32>) -> Self {
         Self::Uints(x)
     }
 }
-impl From<i32> for AttrValue {
+impl From<i32> for AttributeValue {
     fn from(x: i32) -> Self {
         Self::Int(x)
     }
 }
-impl From<Vec<i32>> for AttrValue {
+impl From<Vec<i32>> for AttributeValue {
     fn from(x: Vec<i32>) -> Self {
         Self::Ints(x)
     }
 }
-impl From<u64> for AttrValue {
+impl From<u64> for AttributeValue {
     fn from(x: u64) -> Self {
         Self::Ulonglong(x)
     }
 }
-impl From<Vec<u64>> for AttrValue {
+impl From<Vec<u64>> for AttributeValue {
     fn from(x: Vec<u64>) -> Self {
         Self::Ulonglongs(x)
     }
 }
-impl From<i64> for AttrValue {
+impl From<i64> for AttributeValue {
     fn from(x: i64) -> Self {
         Self::Longlong(x)
     }
 }
-impl From<Vec<i64>> for AttrValue {
+impl From<Vec<i64>> for AttributeValue {
     fn from(x: Vec<i64>) -> Self {
         Self::Longlongs(x)
     }
 }
-impl From<f32> for AttrValue {
+impl From<f32> for AttributeValue {
     fn from(x: f32) -> Self {
         Self::Float(x)
     }
 }
-impl From<Vec<f32>> for AttrValue {
+impl From<Vec<f32>> for AttributeValue {
     fn from(x: Vec<f32>) -> Self {
         Self::Floats(x)
     }
 }
-impl From<f64> for AttrValue {
+impl From<f64> for AttributeValue {
     fn from(x: f64) -> Self {
         Self::Double(x)
     }
 }
-impl From<Vec<f64>> for AttrValue {
+impl From<Vec<f64>> for AttributeValue {
     fn from(x: Vec<f64>) -> Self {
         Self::Doubles(x)
     }
 }
-impl From<&str> for AttrValue {
+impl From<&str> for AttributeValue {
     fn from(x: &str) -> Self {
         Self::Str(x.to_string())
     }
 }
-impl From<String> for AttrValue {
+impl From<String> for AttributeValue {
     fn from(x: String) -> Self {
         Self::Str(x)
     }
 }
-impl From<Vec<String>> for AttrValue {
+impl From<Vec<String>> for AttributeValue {
     fn from(x: Vec<String>) -> Self {
         Self::Strs(x)
     }
 }
-impl From<&[String]> for AttrValue {
+impl From<&[String]> for AttributeValue {
     fn from(x: &[String]) -> Self {
         Self::Strs(x.to_vec())
     }
 }
-impl From<&[&str]> for AttrValue {
+impl From<&[&str]> for AttributeValue {
     fn from(x: &[&str]) -> Self {
         Self::Strs(x.iter().map(|&s| String::from(s)).collect())
     }
 }
-impl From<Vec<&str>> for AttrValue {
+impl From<Vec<&str>> for AttributeValue {
     fn from(x: Vec<&str>) -> Self {
         Self::from(x.as_slice())
     }
@@ -884,172 +884,172 @@ impl From<Vec<&str>> for AttrValue {
 #[test]
 fn conversion() {
     let x = 1.0f32;
-    let _b: AttrValue = x.into();
+    let _b: AttributeValue = x.into();
 }
 
-impl TryFrom<AttrValue> for u8 {
+impl TryFrom<AttributeValue> for u8 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<u8, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<u8, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok(x),
-            AttrValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ushort(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
-            _ => Err("Conversion not supported".into()),
-        }
-    }
-}
-
-impl TryFrom<AttrValue> for i8 {
-    type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<i8, Self::Error> {
-        match attr {
-            AttrValue::Uchar(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Schar(x) => Ok(x),
-            AttrValue::Ushort(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uchar(x) => Ok(x),
+            AttributeValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ushort(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
 
-impl TryFrom<AttrValue> for u16 {
+impl TryFrom<AttributeValue> for i8 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<u16, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<i8, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok((x).into()),
-            AttrValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ushort(x) => Ok(x),
-            AttrValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uchar(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Schar(x) => Ok(x),
+            AttributeValue::Ushort(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
 
-impl TryFrom<AttrValue> for i16 {
+impl TryFrom<AttributeValue> for u16 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<i16, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<u16, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok((x).into()),
-            AttrValue::Schar(x) => Ok((x).into()),
-            AttrValue::Ushort(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Short(x) => Ok(x),
-            AttrValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uchar(x) => Ok((x).into()),
+            AttributeValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ushort(x) => Ok(x),
+            AttributeValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
-impl TryFrom<AttrValue> for u32 {
+
+impl TryFrom<AttributeValue> for i16 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<u32, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<i16, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok((x).into()),
-            AttrValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ushort(x) => Ok((x).into()),
-            AttrValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Uint(x) => Ok(x),
-            AttrValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uchar(x) => Ok((x).into()),
+            AttributeValue::Schar(x) => Ok((x).into()),
+            AttributeValue::Ushort(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Short(x) => Ok(x),
+            AttributeValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
-impl TryFrom<AttrValue> for i32 {
+impl TryFrom<AttributeValue> for u32 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<i32, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<u32, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok((x).into()),
-            AttrValue::Schar(x) => Ok((x).into()),
-            AttrValue::Ushort(x) => Ok((x).into()),
-            AttrValue::Short(x) => Ok((x).into()),
-            AttrValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Int(x) => Ok(x),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uchar(x) => Ok((x).into()),
+            AttributeValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ushort(x) => Ok((x).into()),
+            AttributeValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uint(x) => Ok(x),
+            AttributeValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
-impl TryFrom<AttrValue> for u64 {
+impl TryFrom<AttributeValue> for i32 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<u64, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<i32, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok((x).into()),
-            AttrValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ushort(x) => Ok((x).into()),
-            AttrValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Uint(x) => Ok((x).into()),
-            AttrValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Ulonglong(x) => Ok(x),
-            AttrValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uchar(x) => Ok((x).into()),
+            AttributeValue::Schar(x) => Ok((x).into()),
+            AttributeValue::Ushort(x) => Ok((x).into()),
+            AttributeValue::Short(x) => Ok((x).into()),
+            AttributeValue::Uint(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Int(x) => Ok(x),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
-impl TryFrom<AttrValue> for i64 {
+impl TryFrom<AttributeValue> for u64 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<i64, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<u64, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok((x).into()),
-            AttrValue::Schar(x) => Ok((x).into()),
-            AttrValue::Ushort(x) => Ok((x).into()),
-            AttrValue::Short(x) => Ok((x).into()),
-            AttrValue::Uint(x) => Ok((x).into()),
-            AttrValue::Int(x) => Ok((x).into()),
-            AttrValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
-            AttrValue::Longlong(x) => Ok(x),
+            AttributeValue::Uchar(x) => Ok((x).into()),
+            AttributeValue::Schar(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ushort(x) => Ok((x).into()),
+            AttributeValue::Short(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Uint(x) => Ok((x).into()),
+            AttributeValue::Int(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Ulonglong(x) => Ok(x),
+            AttributeValue::Longlong(x) => (x).try_into().map_err(error::Error::Conversion),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
-impl TryFrom<AttrValue> for f32 {
+impl TryFrom<AttributeValue> for i64 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<f32, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<i64, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok(x as _),
-            AttrValue::Schar(x) => Ok(x as _),
-            AttrValue::Ushort(x) => Ok(x as _),
-            AttrValue::Short(x) => Ok(x as _),
-            AttrValue::Uint(x) => Ok(x as _),
-            AttrValue::Int(x) => Ok(x as _),
-            AttrValue::Ulonglong(x) => Ok(x as _),
-            AttrValue::Longlong(x) => Ok(x as _),
-            AttrValue::Float(x) => Ok(x),
-            AttrValue::Double(x) => Ok(x as _),
+            AttributeValue::Uchar(x) => Ok((x).into()),
+            AttributeValue::Schar(x) => Ok((x).into()),
+            AttributeValue::Ushort(x) => Ok((x).into()),
+            AttributeValue::Short(x) => Ok((x).into()),
+            AttributeValue::Uint(x) => Ok((x).into()),
+            AttributeValue::Int(x) => Ok((x).into()),
+            AttributeValue::Ulonglong(x) => (x).try_into().map_err(error::Error::Conversion),
+            AttributeValue::Longlong(x) => Ok(x),
             _ => Err("Conversion not supported".into()),
         }
     }
 }
-impl TryFrom<AttrValue> for f64 {
+impl TryFrom<AttributeValue> for f32 {
     type Error = error::Error;
-    fn try_from(attr: AttrValue) -> Result<f64, Self::Error> {
+    fn try_from(attr: AttributeValue) -> Result<f32, Self::Error> {
         match attr {
-            AttrValue::Uchar(x) => Ok(x as _),
-            AttrValue::Schar(x) => Ok(x as _),
-            AttrValue::Ushort(x) => Ok(x as _),
-            AttrValue::Short(x) => Ok(x as _),
-            AttrValue::Uint(x) => Ok(x as _),
-            AttrValue::Int(x) => Ok(x as _),
-            AttrValue::Ulonglong(x) => Ok(x as _),
-            AttrValue::Longlong(x) => Ok(x as _),
-            AttrValue::Float(x) => Ok(x as _),
-            AttrValue::Double(x) => Ok(x),
+            AttributeValue::Uchar(x) => Ok(x as _),
+            AttributeValue::Schar(x) => Ok(x as _),
+            AttributeValue::Ushort(x) => Ok(x as _),
+            AttributeValue::Short(x) => Ok(x as _),
+            AttributeValue::Uint(x) => Ok(x as _),
+            AttributeValue::Int(x) => Ok(x as _),
+            AttributeValue::Ulonglong(x) => Ok(x as _),
+            AttributeValue::Longlong(x) => Ok(x as _),
+            AttributeValue::Float(x) => Ok(x),
+            AttributeValue::Double(x) => Ok(x as _),
+            _ => Err("Conversion not supported".into()),
+        }
+    }
+}
+impl TryFrom<AttributeValue> for f64 {
+    type Error = error::Error;
+    fn try_from(attr: AttributeValue) -> Result<f64, Self::Error> {
+        match attr {
+            AttributeValue::Uchar(x) => Ok(x as _),
+            AttributeValue::Schar(x) => Ok(x as _),
+            AttributeValue::Ushort(x) => Ok(x as _),
+            AttributeValue::Short(x) => Ok(x as _),
+            AttributeValue::Uint(x) => Ok(x as _),
+            AttributeValue::Int(x) => Ok(x as _),
+            AttributeValue::Ulonglong(x) => Ok(x as _),
+            AttributeValue::Longlong(x) => Ok(x as _),
+            AttributeValue::Float(x) => Ok(x as _),
+            AttributeValue::Double(x) => Ok(x),
             _ => Err("Conversion not supported".into()),
         }
     }
@@ -1058,10 +1058,10 @@ impl TryFrom<AttrValue> for f64 {
 #[test]
 fn roundtrip_attrvalue() {
     let x: u8 = 5;
-    let attr: AttrValue = x.into();
+    let attr: AttributeValue = x.into();
     assert_eq!(x, attr.try_into().unwrap());
 
     let x: f32 = 5.0;
-    let attr: AttrValue = x.into();
+    let attr: AttributeValue = x.into();
     assert_eq!(x, attr.try_into().unwrap());
 }

--- a/netcdf/src/dimension.rs
+++ b/netcdf/src/dimension.rs
@@ -11,14 +11,15 @@ use std::marker::PhantomData;
 pub struct Dimension<'g> {
     /// None when unlimited (size = 0)
     pub(crate) len: Option<core::num::NonZeroUsize>,
-    pub(crate) id: Identifier,
+    pub(crate) id: DimensionIdentifier,
     pub(crate) _group: PhantomData<&'g nc_type>,
 }
 
-/// Unique identifier for a dimensions in a file. Used when
-/// names can not be used directly
+/// Unique identifier for a dimension in a file. Used when
+/// names can not be used directly, for example when dealing
+/// with nested groups
 #[derive(Debug, Copy, Clone)]
-pub struct Identifier {
+pub struct DimensionIdentifier {
     pub(crate) ncid: nc_type,
     pub(crate) dimid: nc_type,
 }
@@ -65,7 +66,7 @@ impl<'g> Dimension<'g> {
 
     /// Grabs the unique identifier for this dimension, which
     /// can be used in `add_variable_from_identifiers`
-    pub fn identifier(&self) -> Identifier {
+    pub fn identifier(&self) -> DimensionIdentifier {
         self.id
     }
 }
@@ -118,7 +119,7 @@ pub(crate) fn from_name<'f>(loc: nc_type, name: &str) -> error::Result<Option<Di
 
     Ok(Some(Dimension {
         len: core::num::NonZeroUsize::new(dimlen),
-        id: Identifier { ncid: loc, dimid },
+        id: DimensionIdentifier { ncid: loc, dimid },
         _group: PhantomData,
     }))
 }
@@ -170,7 +171,7 @@ pub(crate) fn dimensions_from_location<'g>(
         }
         Ok(Dimension {
             len: core::num::NonZeroUsize::new(dimlen),
-            id: Identifier { ncid, dimid },
+            id: DimensionIdentifier { ncid, dimid },
             _group: PhantomData,
         })
     }))
@@ -220,7 +221,7 @@ pub(crate) fn dimensions_from_variable<'g>(
         }
         Ok(Dimension {
             len: core::num::NonZeroUsize::new(dimlen),
-            id: Identifier { ncid, dimid },
+            id: DimensionIdentifier { ncid, dimid },
             _group: PhantomData,
         })
     }))
@@ -265,7 +266,7 @@ pub(crate) fn dimension_from_name<'f>(
     }
     Ok(Some(Dimension {
         len: core::num::NonZeroUsize::new(dimlen),
-        id: super::dimension::Identifier { ncid, dimid },
+        id: super::dimension::DimensionIdentifier { ncid, dimid },
         _group: PhantomData,
     }))
 }
@@ -284,7 +285,7 @@ pub(crate) fn add_dimension_at<'f>(
     }
     Ok(Dimension {
         len: core::num::NonZeroUsize::new(dimid.try_into()?),
-        id: Identifier { ncid, dimid },
+        id: DimensionIdentifier { ncid, dimid },
         _group: PhantomData,
     })
 }

--- a/netcdf/src/error.rs
+++ b/netcdf/src/error.rs
@@ -169,7 +169,7 @@ impl fmt::Display for Error {
 }
 
 /// Result type used in this crate
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub(crate) fn checked(err: nc_type) -> Result<()> {
     if err != netcdf_sys::NC_NOERR {

--- a/netcdf/src/extent.rs
+++ b/netcdf/src/extent.rs
@@ -247,7 +247,7 @@ impl Extent {
 ///
 /// This type can be constructed in many ways
 /// ```rust,no_run
-/// use netcdf::extent::{Extent, Extents};
+/// use netcdf::{Extent, Extents};
 /// // Get all values
 /// let _: Extents = (..).into();
 /// // Get array with only first 10 of the first dimension

--- a/netcdf/src/group.rs
+++ b/netcdf/src/group.rs
@@ -1,8 +1,7 @@
 //! All netcdf items belong in the root group, which can
 //! be interacted with to get the underlying data
 
-use super::attribute::AttrValue;
-use super::attribute::Attribute;
+use super::attribute::{Attribute, AttributeValue};
 use super::dimension::Dimension;
 use super::error;
 use super::variable::{NcPutGet, Variable, VariableMut};
@@ -20,7 +19,10 @@ pub struct Group<'f> {
 }
 
 #[derive(Debug)]
-/// Mutable access to a group
+/// Mutable access to a group.
+///
+/// This type derefs to a [`Group`](Group), which means [`GroupMut`](Self)
+/// can be used where [`Group`](Group) is expected
 #[allow(clippy::module_name_repetitions)]
 pub struct GroupMut<'f>(
     pub(crate) Group<'f>,
@@ -85,7 +87,7 @@ impl<'f> Group<'f> {
             .map(Result::unwrap)
     }
     /// Get the attribute value
-    pub fn attribute_value(&self, name: &str) -> Option<error::Result<AttrValue>> {
+    pub fn attribute_value(&self, name: &str) -> Option<error::Result<AttributeValue>> {
         self.attribute(name).as_ref().map(Attribute::value)
     }
 
@@ -207,7 +209,7 @@ impl<'f> GroupMut<'f> {
     /// Add an attribute to the group
     pub fn add_attribute<'a, T>(&'a mut self, name: &str, val: T) -> error::Result<Attribute<'a>>
     where
-        T: Into<AttrValue>,
+        T: Into<AttributeValue>,
     {
         let (ncid, name) = super::group::get_parent_ncid_and_stem(self.id(), name)?;
         Attribute::put(ncid, NC_GLOBAL, name, val.into())
@@ -268,7 +270,7 @@ impl<'f> GroupMut<'f> {
     pub fn add_variable_from_identifiers<'g, T>(
         &'g mut self,
         name: &str,
-        dims: &[super::dimension::Identifier],
+        dims: &[super::dimension::DimensionIdentifier],
     ) -> error::Result<VariableMut<'g>>
     where
         T: NcPutGet,

--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -9,8 +9,8 @@
 //! See the [`CF Conventions`](http://cfconventions.org/) for conventions used for climate and
 //! forecast models.
 //!
-//! To explore the documentation, see the `Functions` section, in particular
-//! `open()`, `create()`, and `append()`.
+//! To explore the documentation, see the [`Functions`](#functions) section, in particular
+//! [`open()`](open), [`create()`](create), and [`append()`](append).
 //!
 //! For more information see:
 //! * [The official introduction to `netCDF`](https://docs.unidata.ucar.edu/nug/current/netcdf_introduction.html)
@@ -91,25 +91,28 @@ use lazy_static::lazy_static;
 use netcdf_sys::nc_type;
 use std::sync::Mutex;
 
-pub mod attribute;
-pub mod dimension;
-pub mod error;
-pub mod extent;
-pub mod file;
-pub mod group;
+pub(crate) mod attribute;
+pub(crate) mod dimension;
+pub(crate) mod error;
+pub(crate) mod extent;
+pub(crate) mod file;
+pub(crate) mod group;
 pub mod types;
-pub mod variable;
+pub(crate) mod variable;
 
-pub use attribute::*;
-pub use dimension::*;
-pub use file::*;
-pub use group::*;
-pub use variable::*;
+pub use attribute::{Attribute, AttributeValue};
+pub use dimension::{Dimension, DimensionIdentifier};
+pub use error::{Error, Result};
+pub use extent::{Extent, Extents};
+pub(crate) use file::RawFile;
+pub use file::{File, FileMut, Options};
+pub use group::{Group, GroupMut};
+pub use variable::{Endianness, NcPutGet, Variable, VariableMut};
 
 /// Open a netcdf file in create mode
 ///
 /// Will create a `netCDF4` file and overwrite existing file
-pub fn create<P>(name: P) -> error::Result<MutableFile>
+pub fn create<P>(name: P) -> error::Result<FileMut>
 where
     P: AsRef<std::path::Path>,
 {
@@ -117,7 +120,7 @@ where
 }
 
 /// Open a `netCDF` file in create mode with the given options
-pub fn create_with<P>(name: P, options: Options) -> error::Result<MutableFile>
+pub fn create_with<P>(name: P, options: Options) -> error::Result<FileMut>
 where
     P: AsRef<std::path::Path>,
 {
@@ -125,7 +128,7 @@ where
 }
 
 /// Open a `netCDF` file in append mode
-pub fn append<P>(name: P) -> error::Result<MutableFile>
+pub fn append<P>(name: P) -> error::Result<FileMut>
 where
     P: AsRef<std::path::Path>,
 {
@@ -133,7 +136,7 @@ where
 }
 
 /// Open a `netCDF` file in append mode with the given options
-pub fn append_with<P>(name: P, options: Options) -> error::Result<MutableFile>
+pub fn append_with<P>(name: P, options: Options) -> error::Result<FileMut>
 where
     P: AsRef<std::path::Path>,
 {

--- a/netcdf/tests/attributes.rs
+++ b/netcdf/tests/attributes.rs
@@ -1,4 +1,4 @@
-use netcdf::attribute::AttrValue;
+use netcdf::AttributeValue;
 
 mod common;
 use common::test_location;
@@ -69,7 +69,7 @@ fn open_pres_temp_4d() {
             .expect("Could not find attribute")
             .value()
             .unwrap(),
-        AttrValue::Str("hPa".to_string())
+        AttributeValue::Str("hPa".to_string())
     );
 }
 #[test]
@@ -83,7 +83,7 @@ fn global_attrs() {
         .expect("Could not find attribute");
     let chi = ch1_attr.value().unwrap();
     let eps = 1e-6;
-    if let AttrValue::Float(x) = chi {
+    if let AttributeValue::Float(x) = chi {
         assert!((x - 40.65863).abs() < eps);
     } else {
         panic!("Did not get the expected attr type");
@@ -91,7 +91,7 @@ fn global_attrs() {
 
     let sensor_attr = &file.attribute("sensor").expect("Could not find attribute");
     let sensor_data = sensor_attr.value().unwrap();
-    if let AttrValue::Str(x) = sensor_data {
+    if let AttributeValue::Str(x) = sensor_data {
         assert_eq!("AVHRR/3", x);
     } else {
         panic!("Did not get the expected attr type");
@@ -130,59 +130,59 @@ fn all_attr_types() {
         let file = netcdf::open(f).unwrap();
 
         assert_eq!(
-            AttrValue::Uchar(3),
+            AttributeValue::Uchar(3),
             file.attribute("attr_ubyte").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Schar(3),
+            AttributeValue::Schar(3),
             file.attribute("attr_byte").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Ushort(3),
+            AttributeValue::Ushort(3),
             file.attribute("attr_ushort").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Short(3),
+            AttributeValue::Short(3),
             file.attribute("attr_short").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Int(3),
+            AttributeValue::Int(3),
             file.attribute("attr_int").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Uint(3),
+            AttributeValue::Uint(3),
             file.attribute("attr_uint").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Ulonglong(3),
+            AttributeValue::Ulonglong(3),
             file.attribute("attr_uint64").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Longlong(3),
+            AttributeValue::Longlong(3),
             file.attribute("attr_int64").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Float(3.2),
+            AttributeValue::Float(3.2),
             file.attribute("attr_float").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Double(3.2),
+            AttributeValue::Double(3.2),
             file.attribute("attr_double").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Str("Hello world!".into()),
+            AttributeValue::Str("Hello world!".into()),
             file.attribute("attr_text").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Strs(strs.clone()),
+            AttributeValue::Strs(strs.clone()),
             file.attribute("attr_str").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Strs(strs),
+            AttributeValue::Strs(strs),
             file.attribute("attr_str_slice").unwrap().value().unwrap()
         );
         assert_eq!(
-            AttrValue::Str(u8string.into()),
+            AttributeValue::Str(u8string.into()),
             file.attribute("attr_text_utf8").unwrap().value().unwrap()
         );
     }

--- a/netcdf/tests/file.rs
+++ b/netcdf/tests/file.rs
@@ -66,7 +66,7 @@ fn fetch_from_path() {
         file.variable("grp/subgrp/var").unwrap().name(),
     );
     match file.attribute("grp/subgrp/attr").unwrap().value().unwrap() {
-        netcdf::AttrValue::Str(string) => assert_eq!(string, "test"),
+        netcdf::AttributeValue::Str(string) => assert_eq!(string, "test"),
         _ => panic!(),
     }
 }

--- a/netcdf/tests/group.rs
+++ b/netcdf/tests/group.rs
@@ -96,7 +96,7 @@ fn add_and_get_from_path() {
     );
     assert!(file.group("missing/subgrp").is_err());
     match file.attribute("a/b/attr").unwrap().value().unwrap() {
-        netcdf::AttrValue::Str(string) => assert_eq!(string, "test"),
+        netcdf::AttributeValue::Str(string) => assert_eq!(string, "test"),
         _ => panic!(),
     }
 }


### PR DESCRIPTION
Removes visible modules (leaving `types`) to make the documentation clearer.

This is a breaking change and may require crate users to update their code