### PR TITLE
Improve `ndarray` integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = [
     "netcdf-src",
 ]
 default-members = ["netcdf", "netcdf-sys"]
+resolver = "2"

--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -49,6 +49,12 @@
 //! let data = var.values_arr::<i32, _>(([40, 0 ,0], [1, 100, 100]))?;
 //! # #[cfg(feature = "ndarray")]
 //! let data = var.values_arr::<i32, _>((40, ..100, ..100))?;
+//!
+//! // You can read into an ndarray to reuse an allocation
+//! # #[cfg(feature = "ndarray")]
+//! let mut data = ndarray::Array::<f32, _>::zeros((100, 100));
+//! # #[cfg(feature = "ndarray")]
+//! var.values_arr_into((0, .., ..), data.view_mut())?;
 //! # Ok(()) }
 //! ```
 //!
@@ -69,7 +75,8 @@
 //!             "crab_coolness_level",
 //!             &["time", "ncrabs"],
 //! )?;
-//! // Metadata can be added to the variable
+//! // Metadata can be added to the variable, but will not be used when
+//! // writing or reading data
 //! var.add_attribute("units", "Kelvin")?;
 //! var.add_attribute("add_offset", 273.15_f32)?;
 //!
@@ -80,6 +87,12 @@
 //! // Values can be added along the unlimited dimension, which
 //! // resizes along the `time` axis
 //! var.put_values(&data, (11, ..))?;
+//!
+//! // Using the ndarray feature you can also use
+//! # #[cfg(feature = "ndarray")]
+//! let values = ndarray::Array::from_shape_fn((5, 10), |(j, i)| (j * 10 + i) as f32);
+//! # #[cfg(feature = "ndarray")]
+//! var.put_values_arr((11.., ..), values.view())?;
 //! # Ok(()) }
 //! ```
 

--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -38,6 +38,7 @@
 //! let data_i32 = var.value::<i32, _>((40, 0, 0))?;
 //!
 //! // You can use `values_arr()` to get all the data from the variable.
+//! // This requires the `ndarray` feature
 //! // Passing `..` will give you the entire slice
 //! # #[cfg(feature = "ndarray")]
 //! let data = var.values_arr::<i32, _>(..)?;
@@ -46,6 +47,7 @@
 //! // `(40, 0, 0)` and get a dataset of size `100, 100` from this
 //! # #[cfg(feature = "ndarray")]
 //! let data = var.values_arr::<i32, _>(([40, 0 ,0], [1, 100, 100]))?;
+//! # #[cfg(feature = "ndarray")]
 //! let data = var.values_arr::<i32, _>((40, ..100, ..100))?;
 //! # Ok(()) }
 //! ```

--- a/netcdf/src/variable.rs
+++ b/netcdf/src/variable.rs
@@ -820,7 +820,19 @@ impl<'g> Variable<'g> {
     /// Fetches variable
     fn values_arr_mono<T: NcPutGet>(&self, extents: &Extents) -> error::Result<ArrayD<T>> {
         let dims = self.dimensions();
-        let (start, count, stride) = extents.get_start_count_stride(dims)?;
+        let mut start = vec![];
+        let mut count = vec![];
+        let mut stride = vec![];
+        let mut shape = vec![];
+
+        for item in extents.iter_with_dims(dims)? {
+            start.push(item.start);
+            count.push(item.count);
+            stride.push(item.stride);
+            if !item.is_an_index {
+                shape.push(item.count);
+            }
+        }
 
         let number_of_elements = count.iter().copied().fold(1_usize, usize::saturating_mul);
         let mut values = Vec::with_capacity(number_of_elements);
@@ -829,7 +841,7 @@ impl<'g> Variable<'g> {
             values.set_len(number_of_elements);
         };
 
-        Ok(ArrayD::from_shape_vec(count, values).unwrap())
+        Ok(ArrayD::from_shape_vec(shape, values).unwrap())
     }
 
     #[cfg(feature = "ndarray")]


### PR DESCRIPTION
This adds new methods to get into an `ndarray` and to put an `ndarray` at an arbitrary location

As part of the breaking changes introduced in other PRs it might be an idea to change the names of the functions. Possibly `put`, `get`, and `get_into` could be suitable names for the functions interacting with `ndarray`?