### PR TITLE
Fix has-mmap flag for netcdf crate

### DIFF
--- a/netcdf/build.rs
+++ b/netcdf/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    if std::env::var("DEP_NETCDF_SYS_HAS_MMAP").is_ok() {
+    if std::env::var("DEP_NETCDF_HAS_MMAP").is_ok() {
         println!("cargo:rustc-cfg=feature=\"has-mmap\"");
     }
 }

--- a/netcdf/src/file.rs
+++ b/netcdf/src/file.rs
@@ -100,7 +100,7 @@ impl RawFile {
     pub(crate) fn open_from_memory<'buffer>(
         name: Option<&str>,
         mem: &'buffer [u8],
-    ) -> error::Result<MemFile<'buffer>> {
+    ) -> error::Result<FileMem<'buffer>> {
         let cstr = std::ffi::CString::new(name.unwrap_or("/")).unwrap();
         let mut ncid = 0;
         unsafe {
@@ -115,7 +115,7 @@ impl RawFile {
             }))?;
         }
 
-        Ok(MemFile(File(Self { ncid }), PhantomData))
+        Ok(FileMem(File(Self { ncid }), PhantomData))
     }
 }
 
@@ -425,8 +425,8 @@ impl FileMut {
 }
 
 #[cfg(feature = "has-mmap")]
-/// The memory mapped file is kept in this structure to keep the
-/// lifetime of the buffer longer than the file.
+/// The memory mapped file is kept in this structure to extend
+/// the lifetime of the buffer.
 ///
 /// Access a [`File`] through the `Deref` trait,
 /// ```no_run
@@ -438,10 +438,10 @@ impl FileMut {
 /// # Ok(()) }
 /// ```
 #[allow(clippy::module_name_repetitions)]
-pub struct MemFile<'buffer>(File, std::marker::PhantomData<&'buffer [u8]>);
+pub struct FileMem<'buffer>(File, std::marker::PhantomData<&'buffer [u8]>);
 
 #[cfg(feature = "has-mmap")]
-impl<'a> std::ops::Deref for MemFile<'a> {
+impl<'a> std::ops::Deref for FileMem<'a> {
     type Target = File;
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/netcdf/src/file.rs
+++ b/netcdf/src/file.rs
@@ -109,7 +109,7 @@ impl RawFile {
                     cstr.as_ptr(),
                     NC_NOWRITE,
                     mem.len(),
-                    mem.as_ptr() as *const u8 as *mut _,
+                    mem.as_ptr().cast_mut().cast(),
                     &mut ncid,
                 )
             }))?;

--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -117,6 +117,8 @@ pub use attribute::{Attribute, AttributeValue};
 pub use dimension::{Dimension, DimensionIdentifier};
 pub use error::{Error, Result};
 pub use extent::{Extent, Extents};
+#[cfg(feature = "has-mmap")]
+pub use file::FileMem;
 pub(crate) use file::RawFile;
 pub use file::{File, FileMut, Options};
 pub use group::{Group, GroupMut};
@@ -174,7 +176,7 @@ where
 
 #[cfg(feature = "has-mmap")]
 /// Open a `netCDF` file from a buffer
-pub fn open_mem<'a>(name: Option<&str>, mem: &'a [u8]) -> error::Result<MemFile<'a>> {
+pub fn open_mem<'a>(name: Option<&str>, mem: &'a [u8]) -> error::Result<FileMem<'a>> {
     RawFile::open_from_memory(name, mem)
 }
 


### PR DESCRIPTION
Additionally renames `MemFile` to `FileMem` for consistency with other `File` items

Resolves one of the issues found in #124 where `open_mem` was not available