### PR TITLE
Disable netcdf4 parallel

### DIFF
--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -52,6 +52,8 @@ fn main() {
         .define("HDF5_HL_LIBRARY", &hdf5_hl_lib)
         .define("HDF5_INCLUDE_DIR", hdf5_incdir)
         //
+        .define("ENABLE_PARALLEL4", "OFF") // TODO: Enable mpi support
+        //
         .define("ENABLE_NCZARR", "OFF") // TODO: requires a bunch of deps
         //
         .define("ENABLE_DAP", "OFF") // TODO: feature flag, requires curl


### PR DESCRIPTION
When `hdf5` is built with the parallel option it also tries to build `netcdf` with the same option. We override this and set it to off.

Fixes #139