### PR TITLE
Use feature check options in rust 1.77

### DIFF
--- a/netcdf-src/Cargo.toml
+++ b/netcdf-src/Cargo.toml
@@ -26,6 +26,7 @@ exclude = [
     "source/nctest/**",
     "source/ncdap_test/**",
 ]
+rust-version = "1.77"
 
 [features]
 dap = ["dep:link-cplusplus"]

--- a/netcdf-src/Cargo.toml
+++ b/netcdf-src/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
     "source/nctest/**",
     "source/ncdap_test/**",
 ]
-rust-version = "1.77"
+rust-version = "1.77.0"
 
 [features]
 dap = ["dep:link-cplusplus"]

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -89,14 +89,14 @@ fn main() {
 
     let netcdf = netcdf_config.build();
 
+    // Only forward link options to netcdf-sys, so netcdf-sys can
+    // optionally choose not to use this build
     println!("cargo::metadata=lib=netcdf");
     let search_path = format!("{}/lib", netcdf.display());
     if std::path::Path::new(&search_path).exists() {
         println!("cargo::metadata=search={search_path}");
-        println!("cargo::rustc-link-search={}", search_path);
     } else {
         let search_path = format!("{}/lib64", netcdf.display());
         println!("cargo::metadata=search={search_path}");
-        println!("cargo::rustc-link-search={}", search_path);
     }
 }

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -24,7 +24,7 @@ fn get_hdf5_version() -> String {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=build.rs");
 
     let hdf5_incdir = std::env::var("DEP_HDF5_INCLUDE").unwrap();
     let mut hdf5_lib = std::env::var("DEP_HDF5_LIBRARY").unwrap();
@@ -89,12 +89,14 @@ fn main() {
 
     let netcdf = netcdf_config.build();
 
-    println!("cargo:lib=netcdf");
+    println!("cargo::metadata=lib=netcdf");
     let search_path = format!("{}/lib", netcdf.display());
     if std::path::Path::new(&search_path).exists() {
-        println!("cargo:search={}", search_path);
+        println!("cargo::metadata=search={search_path}");
+        println!("cargo::rustc-link-search={}", search_path);
     } else {
         let search_path = format!("{}/lib64", netcdf.display());
-        println!("cargo:search={}", search_path);
+        println!("cargo::metadata=search={search_path}");
+        println!("cargo::rustc-link-search={}", search_path);
     }
 }

--- a/netcdf-sys/Cargo.toml
+++ b/netcdf-sys/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["external-ffi-bindings", "filesystem", "science"]
 exclude = [
     "testdata/**",
 ]
-rust-version = "1.70"
+rust-version = "1.77"
 
 [dependencies]
 libz-sys = { version = "1.0.25" }

--- a/netcdf-sys/Cargo.toml
+++ b/netcdf-sys/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["external-ffi-bindings", "filesystem", "science"]
 exclude = [
     "testdata/**",
 ]
-rust-version = "1.77"
+rust-version = "1.77.0"
 
 [dependencies]
 libz-sys = { version = "1.0.25" }

--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -295,6 +295,12 @@ fn main() {
         Version::new(4, 9, 2),
     ];
 
+    for version in &versions {
+        // println!("cargo::rustc-check-cfg={version}");
+        println!("cargo::rustc-check-cfg=cfg(feature, values(\"{version}\"))");
+    }
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"has-mmap\"))");
+
     if !versions.contains(&metaheader.version) {
         if versions
             .iter()

--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -128,9 +128,10 @@ impl NcMetaHeader {
     }
 
     fn emit_feature_flags(&self) {
+        println!("cargo::rustc-check-cfg=cfg(feature, values(\"has-mmap\",\"has-dap\"))");
         if self.has_dap2 || self.has_dap4 {
-            println!("cargo:rustc-cfg=feature=\"has-dap\"");
-            println!("cargo:has-dap=1");
+            println!("cargo::rustc-cfg=feature=\"has-dap\"");
+            println!("cargo::metadata=has-dap=1");
         } else {
             assert!(
                 feature!("DAP").is_err(),
@@ -138,8 +139,8 @@ impl NcMetaHeader {
             );
         }
         if self.has_mmap {
-            println!("cargo:rustc-cfg=feature=\"has-mmap\"");
-            println!("cargo:has-mmap=1");
+            println!("cargo::rustc-cfg=feature=\"has-mmap\"");
+            println!("cargo::metadata=has-mmap=1");
         } else {
             assert!(
                 feature!("MEMIO").is_err(),
@@ -232,7 +233,7 @@ fn _check_consistent_version_linked() {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=build.rs");
 
     let info;
     if feature!("STATIC").is_ok() {
@@ -242,10 +243,10 @@ fn main() {
         info = NcInfo::gather_from_ncconfig(Some(&netcdf_path.join("..")))
             .unwrap_or_else(|| NcInfo::from_path(&netcdf_path.join("..")));
 
-        println!("cargo:rustc-link-search=native={}", netcdf_path.display());
-        println!("cargo:rustc-link-lib=static={netcdf_lib}");
+        println!("cargo::rustc-link-search=native={}", netcdf_path.display());
+        println!("cargo::rustc-link-lib=static={netcdf_lib}");
     } else {
-        println!("cargo:rerun-if-env-changed=NETCDF_DIR");
+        println!("cargo::rerun-if-env-changed=NETCDF_DIR");
 
         let nc_dir = std::env::var_os("NETCDF_DIR")
             .or_else(|| std::env::var_os("NetCDF_DIR"))
@@ -260,8 +261,8 @@ fn main() {
             NcInfo::gather_from_ncconfig(None).unwrap_or_else(NcInfo::guess)
         };
 
-        println!("cargo:rustc-link-search={}", info.libdir.display());
-        println!("cargo:rustc-link-lib={}", &info.libname);
+        println!("cargo::rustc-link-search={}", info.libdir.display());
+        println!("cargo::rustc-link-lib={}", &info.libname);
     }
 
     let metaheader = NcMetaHeader::gather_from_includeheader(
@@ -273,8 +274,8 @@ fn main() {
 
     // panic!("{:?}", info);
     // Emit nc flags
-    println!("cargo:includedir={}", info.includedir.display());
-    println!("cargo:nc_version={}", metaheader.version);
+    println!("cargo::metadata=includedir={}", info.includedir.display());
+    println!("cargo::metadata=nc_version={}", metaheader.version);
     let versions = [
         Version::new(4, 4, 0),
         Version::new(4, 4, 1),
@@ -296,10 +297,8 @@ fn main() {
     ];
 
     for version in &versions {
-        // println!("cargo::rustc-check-cfg={version}");
         println!("cargo::rustc-check-cfg=cfg(feature, values(\"{version}\"))");
     }
-    println!("cargo::rustc-check-cfg=cfg(feature, values(\"has-mmap\"))");
 
     if !versions.contains(&metaheader.version) {
         if versions

--- a/netcdf-sys/src/mmap.rs
+++ b/netcdf-sys/src/mmap.rs
@@ -2,7 +2,7 @@ use std::os::raw::{c_char, c_int, c_void};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[cfg(feature = "1.6.2")]
+#[cfg(feature = "4.6.2")]
 pub struct NC_memio {
     size: usize,
     memory: *mut c_void,
@@ -18,14 +18,14 @@ extern "C" {
         ncidp: *mut c_int,
     ) -> c_int;
 
-    #[cfg(feature = "1.6.2")]
+    #[cfg(feature = "4.6.2")]
     pub fn nc_create_mem(
         path: *const c_char,
         mode: c_int,
         initialsize: usize,
         ncidp: *mut c_int,
     ) -> c_int;
-    #[cfg(feature = "1.6.2")]
+    #[cfg(feature = "4.6.2")]
     pub fn nc_open_memio(
         path: *const c_char,
         mode: c_int,
@@ -33,6 +33,6 @@ extern "C" {
         ncidp: *mut c_int,
     ) -> c_int;
 
-    #[cfg(feature = "1.6.2")]
+    #[cfg(feature = "4.6.2")]
     pub fn nc_close_memio(ncid: c_int, info: *mut NC_memio) -> c_int;
 }

--- a/netcdf/Cargo.toml
+++ b/netcdf/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 categories = ["science", "filesystem"]
 exclude = ["examples/**", "tests/**"]
 build = "build.rs"
-rust-version = "1.77"
+rust-version = "1.77.0"
 
 [features]
 default = ["ndarray"]

--- a/netcdf/Cargo.toml
+++ b/netcdf/Cargo.toml
@@ -14,6 +14,7 @@ readme = "../README.md"
 categories = ["science", "filesystem"]
 exclude = ["examples/**", "tests/**"]
 build = "build.rs"
+rust-version = "1.77"
 
 [features]
 default = ["ndarray"]

--- a/netcdf/build.rs
+++ b/netcdf/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"has-mmap\"))");
     if std::env::var("DEP_NETCDF_HAS_MMAP").is_ok() {
         println!("cargo:rustc-cfg=feature=\"has-mmap\"");
     }

--- a/netcdf/build.rs
+++ b/netcdf/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(feature, values(\"has-mmap\"))");
     if std::env::var("DEP_NETCDF_HAS_MMAP").is_ok() {
-        println!("cargo:rustc-cfg=feature=\"has-mmap\"");
+        println!("cargo::rustc-cfg=feature=\"has-mmap\"");
     }
     for (env, _value) in std::env::vars() {
         if let Some(version) = env.strip_prefix("DEP_NETCDF_VERSION_") {


### PR DESCRIPTION
[rustc-check-cfg](https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg) wants features to be explicitely declared, to check for in appropriate feature usage. This picked up one bug with `mmap`

Will merge when 1.77 is a more common version