### PR TITLE
Allow user to set CAPATH/CAINFO

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "netcdf-src/source"]
 	path = netcdf-src/source
-	url = https://github.com/gigainfosystems/netcdf-c
+	url = https://github.com/mulimoen/netcdf-c

--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -306,6 +306,10 @@ fn main() {
                 "cargo:rustc-cfg=feature=\"{}.{}.{}\"",
                 version.major, version.minor, version.patch
             );
+            println!(
+                "cargo:version_\"{}.{}.{}\"=1",
+                version.major, version.minor, version.patch
+            );
         }
     }
     metaheader.emit_feature_flags();

--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -284,6 +284,7 @@ fn main() {
         Version::new(4, 8, 1),
         Version::new(4, 9, 0),
         Version::new(4, 9, 1),
+        Version::new(4, 9, 2),
     ];
 
     if !versions.contains(&metaheader.version) {

--- a/netcdf-sys/src/functions.rs
+++ b/netcdf-sys/src/functions.rs
@@ -1728,6 +1728,11 @@ mod netcdf_2 {
         #[cfg(feature = "4.6.2")]
         pub fn nc_initialize() -> c_int;
         pub fn nc_finalize() -> c_int;
+
+        #[cfg(feature = "4.9.2")]
+        pub fn nc_rc_get(key: *const c_char) -> *mut c_char;
+        #[cfg(feature = "4.9.2")]
+        pub fn nc_rc_set(key: *const c_char, value: *const c_char) -> c_int;
     }
 }
 pub use netcdf_2::*;

--- a/netcdf/Cargo.toml
+++ b/netcdf/Cargo.toml
@@ -23,6 +23,7 @@ static = ["netcdf-sys/static"]
 ndarray = { version = "0.15", optional = true }
 netcdf-sys = { workspace = true }
 bitflags = "2.4.2"
+libc = "0.2.154"
 
 [dev-dependencies]
 clap = { version = "4.5.1", features = ["derive"] }

--- a/netcdf/build.rs
+++ b/netcdf/build.rs
@@ -2,4 +2,9 @@ fn main() {
     if std::env::var("DEP_NETCDF_HAS_MMAP").is_ok() {
         println!("cargo:rustc-cfg=feature=\"has-mmap\"");
     }
+    for (env, _value) in std::env::vars() {
+        if let Some(version) = env.strip_prefix("DEP_NETCDF_VERSION_") {
+            println!("cargo:rustc-cfg=feature={version}");
+        }
+    }
 }

--- a/netcdf/src/lib.rs
+++ b/netcdf/src/lib.rs
@@ -110,6 +110,8 @@ pub(crate) mod error;
 pub(crate) mod extent;
 pub(crate) mod file;
 pub(crate) mod group;
+#[cfg(feature = "4.9.2")]
+pub mod rc;
 pub mod types;
 pub(crate) mod variable;
 

--- a/netcdf/src/rc.rs
+++ b/netcdf/src/rc.rs
@@ -1,0 +1,42 @@
+use std::ffi::{c_char, CStr, CString};
+use std::ops::Deref;
+use std::ptr::NonNull;
+
+pub fn set(key: &str, value: &str) -> crate::error::Result<()> {
+    let key = CString::new(key)?;
+    let value = CString::new(value)?;
+    crate::error::checked(crate::with_lock(|| unsafe {
+        netcdf_sys::nc_rc_set(key.as_ptr(), value.as_ptr())
+    }))
+}
+
+#[derive(Debug)]
+pub struct OwnedString {
+    inner: NonNull<c_char>,
+}
+
+impl Deref for OwnedString {
+    type Target = CStr;
+    fn deref(&self) -> &Self::Target {
+        unsafe { CStr::from_ptr(self.inner.as_ptr()) }
+    }
+}
+
+impl Drop for OwnedString {
+    fn drop(&mut self) {
+        unsafe {
+            libc::free(self.inner.as_ptr().cast());
+        }
+    }
+}
+
+pub fn get(key: &str) -> Option<OwnedString> {
+    let key = if let Ok(key) = CString::new(key) {
+        key
+    } else {
+        return None;
+    };
+    let _lock = netcdf_sys::libnetcdf_lock.lock().unwrap();
+    let value = unsafe { netcdf_sys::nc_rc_get(key.as_ptr()) };
+    NonNull::new(value).map(|inner| OwnedString { inner })
+}


### PR DESCRIPTION
This let's one set the certificate for curl, as this is not done by default. The certificate can be set either programatically by the safe wrapper
```rust
    netcdf::rc::set("HTTP.SSL.CAPATH", "/etc/ssl/certs/").unwrap();
```
by using the unsafe c-function
```rust
    unsafe {
        let path = c"HTTP.SSL.CAPATH";
        let value = c"/etc/ssl/certs/";
        let ret = netcdf_sys::nc_rc_set(path.as_ptr(), value.as_ptr());
        assert_eq!(ret, 0);
    }
```
or by setting the information in `~/.ncrc`:
```conf
HTTP.SSL.CAPATH=/etc/ssl/certs/
```

Fixes #141 