### PR TITLE
Fix bad rust-ndarray link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Not (yet) supported:
 * Nested user defined types
 * Writing using memory-mapped file
 
-All variable data is read into a contiguous buffer, or into an [ndarray](https://github.com/rust-ndarray/rust-ndarray) if the `ndarray` feature is activated.
+All variable data is read into a contiguous buffer, or into an [ndarray](https://github.com/rust-ndarray/ndarray) if the `ndarray` feature is activated.
 
 ## Building
 


### PR DESCRIPTION
Minor doc fix. URL linking to `ndarray` in the README was bad, leading readers to a 404. This fixes it.

Thanks. Appreciate your work. 👍 