### PR TITLE
Use netCDF-c v4.9.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Check formatting
       run: cargo fmt -- --check
     - name: Documentation
-      run: cargo doc --workspace --features netcdf/derive
+      run: cargo doc --workspace --features netcdf/derive --exclude netcdf-src
     - name: Clippy
-      run: cargo clippy --features netcdf/derive --workspace -- -D warnings
+      run: cargo clippy --features netcdf/derive --workspace --exclude netcdf-src -- -D warnings
 
   test_apt:
     name: test apt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "netcdf-src/source"]
 	path = netcdf-src/source
-	url = https://github.com/magnusuMET/netcdf-c
+	url = https://github.com/Unidata/netcdf-c

--- a/netcdf-src/Cargo.toml
+++ b/netcdf-src/Cargo.toml
@@ -33,7 +33,7 @@ dap = ["dep:link-cplusplus"]
 mpi = []
 
 [dependencies]
-hdf5-sys = { workspace = true, features = ["hl", "deprecated", "zlib"] }
+hdf5-sys = { workspace = true, features = ["hl", "deprecated", "zlib", "static"] }
 libz-sys = { version = "1.0.25" }
 link-cplusplus = { version = "1.0.9", optional = true }
 

--- a/netcdf-src/README.md
+++ b/netcdf-src/README.md
@@ -2,4 +2,4 @@
 
 Dummy crate for building `netCDF` from source
 
-The current pinned version is 4.9.2
+The current pinned version is 4.9.3

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -26,6 +26,7 @@ fn main() {
         .define("PLUGIN_INSTALL_DIR", "OFF")
         //
         .define("HDF5_ROOT", &hdf5_root)
+        .define("HDF5_USE_STATIC_LIBRARIES", "ON")
         //
         .define("NETCDF_ENABLE_LIBXML2", "OFF") // Use bundled xml2
         //

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -30,9 +30,9 @@ fn main() {
     let mut hdf5_lib = std::env::var("DEP_HDF5_LIBRARY").unwrap();
     let mut hdf5_hl_lib = std::env::var("DEP_HDF5_HL_LIBRARY").unwrap();
 
+    let hdf5_root = format!("{hdf5_incdir}/../");
     #[cfg(unix)]
     {
-        let hdf5_root = format!("{hdf5_incdir}/../");
         let mut hdf5_libdir = format!("{hdf5_root}/lib/");
         if !std::path::Path::new(&hdf5_libdir).exists() {
             hdf5_libdir = format!("{hdf5_root}/lib64/");
@@ -46,32 +46,28 @@ fn main() {
     let mut netcdf_config = cmake::Config::new("source");
     netcdf_config
         .define("BUILD_SHARED_LIBS", "OFF")
-        .define("NC_FIND_SHARED_LIBS", "OFF")
-        .define("BUILD_UTILITIES", "OFF")
-        .define("ENABLE_EXAMPLES", "OFF")
-        .define("ENABLE_DAP_REMOTE_TESTS", "OFF")
-        .define("ENABLE_TESTS", "OFF")
-        .define("ENABLE_EXTREME_NUMBERS", "OFF")
-        .define("ENABLE_PARALLEL_TESTS", "OFF")
-        .define("ENABLE_FILTER_TESTING", "OFF")
+        .define("NETCDF_FIND_SHARED_LIBS", "OFF")
+        .define("NETCDF_BUILD_UTILITIES", "OFF")
+        .define("NETCDF_ENABLE_EXAMPLES", "OFF")
+        .define("NETCDF_ENABLE_DAP_REMOTE_TESTS", "OFF")
+        .define("NETCDF_ENABLE_TESTS", "OFF")
+        .define("NETCDF_ENABLE_EXTREME_NUMBERS", "OFF")
+        .define("NETCDF_ENABLE_PARALLEL_TESTS", "OFF")
+        .define("NETCDF_ENABLE_FILTER_TESTING", "OFF")
         .define("ENABLE_BASH_SCRIPT_TESTING", "OFF")
-        .define("ENABLE_PLUGINS", "OFF")
+        .define("NETCDF_NETCDF_ENABLE_PLUGINS", "OFF")
         .define("PLUGIN_INSTALL_DIR", "OFF")
         //
-        .define("HDF5_VERSION", &hdf5_version)
-        .define("HDF5_C_LIBRARY", &hdf5_lib)
-        .define("HDF5_HL_LIBRARY", &hdf5_hl_lib)
-        .define("HDF5_INCLUDE_DIR", hdf5_incdir)
+        .define("HDF5_ROOT", &hdf5_root)
         //
-        .define("ENABLE_LIBXML2", "OFF") // Use bundled xml2
+        .define("NETCDF_ENABLE_LIBXML2", "OFF") // Use bundled xml2
         //
-        .define("ENABLE_PARALLEL4", "OFF") // TODO: Enable mpi support
+        .define("NETCDF_ENABLE_PARALLEL4", "OFF") // TODO: Enable mpi support
         //
-        .define("ENABLE_NCZARR", "OFF") // TODO: requires a bunch of deps
+        .define("NETCDF_ENABLE_NCZARR", "OFF") // TODO: requires a bunch of deps
         //
-        .define("ENABLE_DAP", "OFF") // TODO: feature flag, requires curl
-        .define("ENABLE_BYTERANGE", "OFF") // TODO: feature flag, requires curl
-        .define("ENABLE_DAP_REMOTE_TESTS", "OFF")
+        .define("NETCDF_ENABLE_DAP", "OFF") // TODO: feature flag, requires curl
+        .define("NETCDF_ENABLE_BYTERANGE", "OFF") // TODO: feature flag, requires curl
         //
         .profile("RelWithDebInfo"); // TODO: detect opt-level
 
@@ -79,8 +75,8 @@ fn main() {
     netcdf_config.define("ZLIB_ROOT", format!("{zlib_include_dir}/.."));
 
     if feature!("DAP").is_ok() {
-        netcdf_config.define("ENABLE_DAP", "ON");
-        netcdf_config.define("ENABLE_BYTERANGE", "ON");
+        netcdf_config.define("NETCDF_ENABLE_DAP", "ON");
+        netcdf_config.define("NETCDF_ENABLE_BYTERANGE", "ON");
     }
 
     if feature!("MPI").is_ok() {

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -19,6 +19,7 @@ fn main() {
         .define("NETCDF_ENABLE_DAP_REMOTE_TESTS", "OFF")
         .define("NETCDF_ENABLE_TESTS", "OFF")
         .define("NETCDF_ENABLE_EXTREME_NUMBERS", "OFF")
+        .define("NETCDF_ENABLE_FILTER_TESTING", "OFF")
         .define("NETCDF_ENABLE_PARALLEL_TESTS", "OFF")
         .define("NETCDF_ENABLE_FILTER_TESTING", "OFF")
         .define("ENABLE_BASH_SCRIPT_TESTING", "OFF")

--- a/netcdf-src/build.rs
+++ b/netcdf-src/build.rs
@@ -4,44 +4,11 @@ macro_rules! feature {
     };
 }
 
-fn get_hdf5_version() -> String {
-    let (major, minor, patch) = std::env::vars()
-        .filter_map(|(key, value)| {
-            key.strip_prefix("DEP_HDF5_VERSION_").map(|key| {
-                assert_eq!(value, "1");
-                let mut version = key.split('_');
-                let major: usize = version.next().unwrap().parse().unwrap();
-                let minor: usize = version.next().unwrap().parse().unwrap();
-                let patch: usize = version.next().unwrap().parse().unwrap();
-
-                (major, minor, patch)
-            })
-        })
-        .max()
-        .expect("Crate hdf5 should have emitted a hdf5 version");
-
-    format!("{major}.{minor}.{patch}")
-}
-
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
 
     let hdf5_incdir = std::env::var("DEP_HDF5_INCLUDE").unwrap();
-    let mut hdf5_lib = std::env::var("DEP_HDF5_LIBRARY").unwrap();
-    let mut hdf5_hl_lib = std::env::var("DEP_HDF5_HL_LIBRARY").unwrap();
-
     let hdf5_root = format!("{hdf5_incdir}/../");
-    #[cfg(unix)]
-    {
-        let mut hdf5_libdir = format!("{hdf5_root}/lib/");
-        if !std::path::Path::new(&hdf5_libdir).exists() {
-            hdf5_libdir = format!("{hdf5_root}/lib64/");
-        }
-        hdf5_lib = format!("{hdf5_libdir}/{hdf5_lib}.a");
-        hdf5_hl_lib = format!("{hdf5_libdir}/{hdf5_hl_lib}.a");
-    }
-
-    let hdf5_version = get_hdf5_version();
 
     let mut netcdf_config = cmake::Config::new("source");
     netcdf_config

--- a/netcdf-src/src/lib.rs
+++ b/netcdf-src/src/lib.rs
@@ -1,6 +1,6 @@
 //! Dummy crate for building `netCDF` from source
 //!
-//! The current pinned version is 4.9.2
+//! The current pinned version is 4.9.3
 
 #[cfg(feature = "dap")]
 extern crate link_cplusplus;

--- a/netcdf-sys/build.rs
+++ b/netcdf-sys/build.rs
@@ -294,6 +294,7 @@ fn main() {
         Version::new(4, 9, 0),
         Version::new(4, 9, 1),
         Version::new(4, 9, 2),
+        Version::new(4, 9, 3),
         // Keep this list up to date with netcdf/build.rs
     ];
 

--- a/netcdf/build.rs
+++ b/netcdf/build.rs
@@ -20,6 +20,7 @@ fn main() {
         Version::new(4, 9, 0),
         Version::new(4, 9, 1),
         Version::new(4, 9, 2),
+        Version::new(4, 9, 3),
         // Keep this list up to date with netcdf-sys/build.rs
     ];
 


### PR DESCRIPTION
[netcdf-c v4.9.3](https://github.com/Unidata/netcdf-c/releases/tag/v4.9.3) has been released, and this PR bumps the static build to use this version. This newly released version incorporates all the fixes maintained in a separate fork.